### PR TITLE
Curl example code Api-Authorization parameter quote fix

### DIFF
--- a/docs/guides/how-to-create-a-link.md
+++ b/docs/guides/how-to-create-a-link.md
@@ -25,7 +25,7 @@ POST https://api.switchy.io/v1/links/create
 ```
 curl 'https://api.switchy.io/v1/links/create' \
   -H 'Content-Type: application/json' \
-  -H 'Api-Authorization': YOUR_TOKEN_HERE
+  -H 'Api-Authorization: YOUR_TOKEN_HERE'
   --data-binary '{"link":{"title":"","description":"","url":"https://example.com/","pixels":[],"showGDPR":false,"extraOptionsLinkRotator":[],"extraOptionsGeolocations":[],"tags":[]}}' \
   --compressed
 ```


### PR DESCRIPTION
When I use -H 'Api-Authorization': YOUR_TOKEN_HERE parameter I get "Missing user token or api tokencurl: (6) Could not resolve host: YOUR_TOKEN_HERE" error. To fix this error we need quote at the end of the token, e.g. 'Api-Authorization: YOUR_TOKEN_HERE'